### PR TITLE
Don't try to configure IPv4 policy routing in a v6-only subnet

### DIFF
--- a/ec2net-functions
+++ b/ec2net-functions
@@ -412,6 +412,10 @@ rewrite_rules_v4() {
     return
   fi
 
+  if ! subnet_supports_ipv4 "$new_ip_address"; then
+    return
+  fi
+
   ips=($(get_ipv4s))
   if [ $? -gt 0 ]; then
     # If we get an error fetching the list of IPs from IMDS,


### PR DESCRIPTION
*Issue: #40*

*Description of changes:*

Add a missing check in `rewrite_rules_v4` to skip configuration if we're in an ipv6-only subnet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
