### PR TITLE
Makefile: Replace the release related makefile targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,16 +18,14 @@ jobs:
     steps:
       - run:
           name: "Install dependencies"
-          command: "dnf -y install rpm-build make git openssh-clients xz"
+          command: "dnf -y install rpm-build make git openssh-clients"
       - checkout
       - run:
           name: "Repack sources"
           command: |
             v=$(rpmspec -q --qf "%{version}" amazon-ec2-net-utils.spec)
-            make tmp-dist
-            mkdir ../amazon-ec2-net-utils-${v}
-            xzcat ../amazon-ec2-net-utils*.tar.xz | tar -C ../amazon-ec2-net-utils-${v} -xf - --strip-components=1
-            tar cvJf amazon-ec2-net-utils-${v}.tar.xz ../amazon-ec2-net-utils-${v}
+            make scratch-sources version=${v}
+            mv ../amazon-ec2-net-utils-${v}.tar.gz .
       - run:
           name: "rpmbuild"
           command: rpmbuild --define "_sourcedir $PWD" -bb amazon-ec2-net-utils.spec
@@ -44,10 +42,10 @@ jobs:
       - run:
           name: "Repack sources"
           command: |
-            v=$(git describe --tags | sed 's,^v,,')
-            make tmp-dist
+            v=$(dpkg-parsechangelog -S Version -l debian/changelog | sed -E 's,^\S:,,; s,-\S+,,')
+            make scratch-sources version=${v}
             DEBEMAIL=nobody@localhost DEBFULLNAME="test runner" dch -v "${v}-1" -b -D unstable "scratch build"
-            mv ../amazon-ec2-net-utils-${v}.tar.xz ../amazon-ec2-net-utils_${v}.orig.tar.xz
+            mv ../amazon-ec2-net-utils-${v}.tar.gz ../amazon-ec2-net-utils_${v}.orig.tar.gz
       - run:
           name: "dpkg-buildpackage"
           command: "dpkg-buildpackage -uc -us"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,5 @@
-VERSION=2.0.0
+pkgname=amazon-ec2-net-utils
+version=2.0.0
 
 # Used by 'install'
 PREFIX?=/usr/local
@@ -17,12 +18,14 @@ DIRS:=${BINDIR} ${UDEVDIR} ${SYSTEMDDIR} ${SYSTEMD_SYSTEM_DIR} ${SYSTEMD_NETWORK
 
 DIST_TARGETS=dist-xz dist-gz
 
+.PHONY: help
 help: ## show help
 	@egrep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 ${DIRS}:
 	install -d $@
 
+.PHONY: install
 install: ${SHELLSCRIPTS} ${UDEVRULES} ${SYSCTL_FILES} | ${DIRS} ## Install the software. Respects DESTDIR
 	$(foreach f,${SHELLSCRIPTS},install -m755 $f ${BINDIR}/$$(basename --suffix=.sh $f);)
 	$(foreach f,${UDEVRULES},install -m644 $f ${UDEVDIR};)
@@ -30,48 +33,32 @@ install: ${SHELLSCRIPTS} ${UDEVRULES} ${SYSCTL_FILES} | ${DIRS} ## Install the s
 	$(foreach f,$(wildcard systemd/system/*.service systemd/system/*.timer),install -m644 $f ${SYSTEMD_SYSTEM_DIR};)
 	$(foreach f,${SYSCTL_FILES},install -m644 $f ${SYSCTL_DIR})
 
+.PHONY: check
 check: ## Run tests
 	@set -x; for script in ${SHELLSCRIPTS}; do \
 		shellcheck --severity warning $${script};\
 	done
 
-dist-tar:
-	git archive --format tar --prefix amazon-ec2-net-utils-$(VERSION)/ v$(VERSION) > ../amazon-ec2-net-utils-$(VERSION).tar
+.PHONY: scratch-sources
+scratch-sources: version=$(shell git describe --dirty --tags)
+scratch-sources: ## generate a tarball based on the current working copy
+	tar czf ../${pkgname}-${version}.tar.gz --exclude=.git --transform 's,^./,./${pkgname}-${version}/,' .
 
-dist-xz: dist-tar
-	xz --keep ../amazon-ec2-net-utils-$(VERSION).tar
+.PHONY: release-sources
+release-sources: uncommitted-check head-check ## generate a release tarball
+	git archive --format tar.gz --prefix ${pkgname}-${version}/ HEAD > ../${pkgname}-${version}.tar.gz
 
-dist-gz: dist-tar
-	gzip -c ../amazon-ec2-net-utils-$(VERSION).tar > ../amazon-ec2-net-utils-$(VERSION).tar.gz
-
-dist: dist-hook
-	$(MAKE) $(DIST_TARGETS)
-	rm ../amazon-ec2-net-utils-$(VERSION).tar
-
-tmp-dist: uncommitted-check
-	$(MAKE) $(AM_MAKEFLAGS) VERSION=$(patsubst v%,%,$(shell git describe --tags)) DISTHOOK=0 dist
-
+.PHONY: uncommitted-check
 uncommitted-check:
 	@if ! git update-index --refresh --unmerged || \
 		! git diff-index --name-only --exit-code HEAD; then \
 	echo "*** ERROR: Uncommitted changes in above files"; exit 1; fi
 
-version-check:
-	@if [ -z "$(VERSION)" ]; then \
-		echo "*** ERROR: VERSION not set"; exit 1; fi
+.PHONY: head-check
+head-check:
+	@if ! git diff --name-only --exit-code v${version} HEAD > /dev/null; then \
+		echo "*** ERROR: Git checkout not at version ${version}"; exit 1; fi ; \
 
- DISTHOOK=1
-dist-hook: uncommitted-check
-	if [ $(DISTHOOK) = 1 ]; then \
-         if ! git rev-parse --verify v$(VERSION) > /dev/null 2>&1; then \
-         echo "*** ERROR: Version v$(VERSION) is not tagged"; exit 1; fi ; \
-         if ! git diff --name-only --exit-code v$(VERSION) HEAD > /dev/null; then \
-         echo "*** ERROR: Git checkout not at version v$(VERSION)"; exit 1; fi ; \
-     fi
-
-tag: uncommitted-check version-check
-	@if git rev-parse --verify v$(VERSION) > /dev/null 2>&1; then \
-		echo "*** ERROR: Version v$(VERSION) is already tagged"; exit 1; fi
-	@git tag v$(VERSION)
-
-.PHONY: dirs check install all dist dist-hook dist-tar dist-xz version-check tag
+tag: uncommitted-check version-check ## Tag a new release
+	@if git rev-parse --verify v$(version) > /dev/null 2>&1; then \
+		echo "*** ERROR: Version $(VERSION) is already tagged"; exit 1; fi

--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -5,7 +5,7 @@ Summary: utilities for managing network interfaces in Amazon EC2
 
 License: Apache 2.0
 URL:     https://github.com/aws/amazon-ec2-net-utils/
-Source0: amazon-ec2-net-utils-%{version}.tar.xz
+Source0: amazon-ec2-net-utils-%{version}.tar.gz
 
 BuildArch: noarch
 


### PR DESCRIPTION
The PR updates the Makefile targets that are used when tagging releases and generating their corresponding tarballs. Since the CircleCI config makes use of these targets, it is updated to reflect the changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

cc @halfdime-code
