### PR TITLE
Fix udev generation of 70-persistent-net.rules

### DIFF
--- a/75-persistent-net-generator.rules
+++ b/75-persistent-net-generator.rules
@@ -9,12 +9,10 @@ SUBSYSTEM!="net", GOTO="persistent_net_generator_end"
 KERNEL!="eth*", GOTO="persistent_net_generator_end"
 ACTION!="add", GOTO="persistent_net_generator_end"
 NAME=="?*", GOTO="persistent_net_generator_end"
+DEVPATH=="/devices/virtual/*", GOTO="persistent_net_generator_end"
 
 # do not create rule for eth0
 ENV{INTERFACE}=="eth0", GOTO="persistent_net_generator_end"
-
-# do not create rule if interface uses unrecognized driver
-ENV{ID_NET_DRIVER}!="vif|ena|ixgbevf", GOTO="persistent_net_generator_end"
 
 # read MAC address
 ENV{MATCHADDR}="$attr{address}"


### PR DESCRIPTION
*Issue #, if available:* #48

*Description of changes:*

Commit 1cddb38 ("Ignore interfaces that use unrecognized drivers") made use of an environment variable that is not available at the time of processing the kernel udev events.  Consequently, generation of 70-persistent-net.rules was skipped in all conditions, when the intent was for it to be generated when processing interfaces backed by actual ENI devices.

We fix this by looking at the `DEVPATH` key instead of the `ENV{ID_NET_DRIVER}` variable, as it has been set at the time of rule
processing, and skipping virtual interfaces (e.g. vlan sub-interfaces).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
