### PR TITLE
Don't call ec2ifup for virtual interfaces

### DIFF
--- a/53-ec2-network-interfaces.rules.systemd
+++ b/53-ec2-network-interfaces.rules.systemd
@@ -4,5 +4,5 @@
 # for the specific language governing permissions and limitations under
 # the License.
 
-ACTION=="add", SUBSYSTEM=="net", KERNEL=="eth*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="ec2net-ifup@$env{INTERFACE}"
+ACTION=="add", SUBSYSTEM=="net", KERNEL=="eth*", DEVPATH!="/devices/virtual/*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="ec2net-ifup@$env{INTERFACE}"
 ACTION=="remove", SUBSYSTEM=="net", KERNEL=="eth*", RUN+="/usr/sbin/ec2ifdown $env{INTERFACE}"


### PR DESCRIPTION
*Description of changes:*

Virtual interfaces such as vlan interfaces would trigger ifupdown, resulting in an attempt to configure an interface that was not an ENI as if it was.

*Issue #:* #49 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
