### PR TITLE
1.x: Add optional provisioning of ipv4 delegated prefix IPs

### DIFF
--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -16,6 +16,7 @@ URL:       https://github.com/aws/amazon-ec2-net-utils
 BuildArch: noarch
 Requires:  curl
 Requires:  iproute
+Requires:  initscripts
 BuildRequires: make
 BuildRequires: systemd
 %if %{systemd}

--- a/ec2net-functions
+++ b/ec2net-functions
@@ -156,8 +156,38 @@ get_primary_ipv4() {
 get_secondary_ipv4s() {
   ipv4s=($(get_ipv4s))
   ec=$?
+  if should_provision_prefix_ips "${config_file}"; then
+    ipv4s+=($(get_delegated_ipv4s $dpfx))
+  fi
   echo "${ipv4s[@]:1}"
   return $ec
+}
+
+get_delegated_ipv4s() {
+  for dpfx in $(get_delegated_prefix ipv4); do
+    get_cidr_ipv4s $dpfx
+  done
+}
+
+get_cidr_ipv4s() {
+  local ipv4_cidr=$1
+  local so1 so2 so3 so4 eo1 eo2 eo3 eo4
+
+  local ipv4_start=$(ipcalc -n $ipv4_cidr | cut -f2 -d=)
+  local ipv4_end=$(ipcalc -b $ipv4_cidr | cut -f2 -d=)
+
+  IFS=. read -r so1 so2 so3 so4 <<< "$ipv4_start"
+  IFS=. read -r eo1 eo2 eo3 eo4 <<< "$ipv4_end"
+
+  for ((i1=$so1; i1<=$eo1; i1++)); do
+    for ((i2=$so2; i2<=$eo2; i2++)); do
+      for ((i3=$so3; i3<=$eo3; i3++)); do
+        for ((i4=$so4; i4<=$eo4; i4++)); do
+          echo $i1.$i2.$i3.$i4
+        done
+      done
+    done
+  done
 }
 
 get_delegated_prefix() {
@@ -166,7 +196,7 @@ get_delegated_prefix() {
     # there's a prefix delegated to this interface.  So when probing
     # for prefix keys, set the get_meta max attempts parameter to 1
     local prefix_tries=1
-    local prefixes=($(get_meta "${af}-prefix" $prefix_tries))
+    local prefixes=($(get_meta "${af}-prefix" $prefix_tries|sort -V))
     ec=$?
     echo "${prefixes[@]}"
     return $ec
@@ -260,6 +290,7 @@ rewrite_primary() {
 	HWADDR=${HWADDR}
 	DEFROUTE=no
 	EC2SYNC=yes
+	EC2PROVISIONPFXIPS=${EC2PROVISIONPFXIPS}
 	MAINROUTETABLE=${MAINROUTETABLE}
 EOF
 

--- a/ec2net-functions-lib
+++ b/ec2net-functions-lib
@@ -78,6 +78,22 @@ should_use_mainroutetable() {
     return 0
 }
 
+# Whether or not all IPs in a delegated prefix should be directly provisioned.
+# Defaults to no for backwards-compatability.
+# Note: Currently only supported for IPv4.
+should_provision_prefix_ips() {
+    local config_file="$1"
+    if [ -s "$config_file" ]; then
+        local provision_prefix_ips
+        provision_prefix_ips=$(LANG=C grep -l "^[[:space:]]*EC2PROVISIONPFXIPS=yes\([[:space:]#]\|$\)" $config_file)
+        if [ "${provision_prefix_ips}" == "${config_file}" ]; then
+            logger --tag ec2net "${interface} prefix ips should be provisioned"
+            return 0
+        fi
+    fi
+    return 1
+}
+
 # Local Variables:
 # mode: shell-script
 # tab-width: 4


### PR DESCRIPTION
*Issue #, if available:*
57

*Description of changes:*

Adds management of the individual addresses inside an ipv4 delegated prefix if the ifcfg option 'EC2PROVISIONPFXIPS' is set. The option defaults to 'no' for back-compat with current behavior.

This uses ipcalc(1) to determine start and stop addresses of the range, which is already included in the initscripts package. I added it as Requires in the spec file, but didn't adjust the Changelog.

Addresses https://github.com/amazonlinux/amazon-ec2-net-utils/issues/57

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
