### PR TITLE
bug: ensure only secondary addresses are used when assigning aliases

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -98,7 +98,7 @@ get_iface_imds() {
     local mac=$1
     local key=$2
     local max_tries=${3:-10}
-    get_imds network/interfaces/macs/${mac}/${key} $max_tries | sort
+    get_imds network/interfaces/macs/${mac}/${key} $max_tries
 }
 
 _install_and_reload() {
@@ -132,7 +132,7 @@ create_ipv4_aliases() {
     local mac=$2
     local addresses
     subnet_supports_ipv4 "$iface" || return 0
-    addresses=$(get_iface_imds $mac local-ipv4s | tail -n +2)
+    addresses=$(get_iface_imds $mac local-ipv4s | tail -n +2 | sort)
     local drop_in_dir="${runtimedir}/70-${iface}.network.d"
     mkdir -p "$drop_in_dir"
     local file="$drop_in_dir/ec2net_alias.conf"


### PR DESCRIPTION
*Issue #, if available:* #63

*Description of changes:*

The `local-ipv4s` IMDS field lists the primary RFC 1918 address on the first line, with secondary IPv4 addresses on subsequent lines.  When assigning alises, we want to only consider secondary IPv4 addresses, so we exclude the primary using `tail -n +2`.  In order to ensure consistent ordering across invocations, even if IMDS returns secondary addresses in unspecified order, the list of secondaries is processed with `sort`.  Prior to this change, we were performing the `sort` operation before the `tail -n +2` operation, meaning that a secondary address that sorted before the primary would be mistakenly interpreted as a primary address, and a secondary address could be mistaken for the primary address.

To fix this, we move the `sort` operation after the `tail -n +2` operation. Technically this could still be broken if IMDS ever stops returning the primary address on the first line of the output, but for now there is no better way to identify the primary address.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
