### PR TITLE
1.x: configure github actions

### DIFF
--- a/.github/Dockerfile.al2-test
+++ b/.github/Dockerfile.al2-test
@@ -1,0 +1,3 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
+
+RUN yum -y install make rpm-build

--- a/.github/container-tests-al2.sh
+++ b/.github/container-tests-al2.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+v=$(rpmspec -q --qf "%{version}" amazon-ec2-net-utils.spec)
+make scratch-sources version=${v}
+mv ../amazon-ec2-net-utils-${v}.tar.gz ${v}.tar.gz
+rpmbuild --define "_sourcedir $PWD" -bb amazon-ec2-net-utils.spec
+
+

--- a/.github/workflows/test-al2.yml
+++ b/.github/workflows/test-al2.yml
@@ -1,0 +1,22 @@
+name: AL2 package build
+
+on:
+  push:
+    branches: [ "1.x" ]
+  pull_request:
+    branches: [ "1.x" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the test container image (AL2)
+      run: docker build . --file .github/Dockerfile.al2-test --tag amazon-ec2-net-utils-tests:al2
+    - name: Run tests in container (AL2)
+      run: docker run -v $(readlink -f $PWD):/src -w /src amazon-ec2-net-utils-tests:al2 make test
+    - name: Build rpm in container (AL2)
+      run: docker run -v $(readlink -f $PWD):/src -w /src --entrypoint "/src/.github/container-tests-al2.sh" amazon-ec2-net-utils-tests:al2


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Similar to the GitHub Actions configuration on the main branch.  This change configured Actions to run `make test` and construct an AL2 package on CRs or pushes to the 1.x branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
