### PR TITLE
Delete obsolete sysctl configuration

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,15 +8,13 @@ UDEVDIR=${DESTDIR}/usr/lib/udev/rules.d
 SYSTEMDDIR=${DESTDIR}/usr/lib/systemd
 SYSTEMD_SYSTEM_DIR=${SYSTEMDDIR}/system
 SYSTEMD_NETWORK_DIR=${SYSTEMDDIR}/network
-SYSCTL_DIR=${DESTDIR}/etc/sysctl.d
 SHARE_DIR=${DESTDIR}/${PREFIX}/share/${pkgname}
 
 SHELLSCRIPTS=$(wildcard bin/*.sh)
 SHELLLIBS=$(wildcard lib/*.sh)
 UDEVRULES=$(wildcard udev/*.rules)
-SYSCTL_FILES=$(wildcard sysctl/*.conf)
 
-DIRS:=${BINDIR} ${UDEVDIR} ${SYSTEMDDIR} ${SYSTEMD_SYSTEM_DIR} ${SYSTEMD_NETWORK_DIR} ${SYSCTL_DIR} ${SHARE_DIR}
+DIRS:=${BINDIR} ${UDEVDIR} ${SYSTEMDDIR} ${SYSTEMD_SYSTEM_DIR} ${SYSTEMD_NETWORK_DIR} ${SHARE_DIR}
 
 DIST_TARGETS=dist-xz dist-gz
 
@@ -32,14 +30,13 @@ sed -i "s,AMAZON_EC2_NET_UTILS_LIBDIR,${PREFIX}/share/${pkgname},g" $1
 endef
 
 .PHONY: install
-install: ${SHELLSCRIPTS} ${UDEVRULES} ${SYSCTL_FILES} ${SHELLLIBS} | ${DIRS} ## Install the software. Respects DESTDIR
+install: ${SHELLSCRIPTS} ${UDEVRULES} ${SHELLLIBS} | ${DIRS} ## Install the software. Respects DESTDIR
 	$(foreach f,${SHELLSCRIPTS},tgt=${BINDIR}/$$(basename --suffix=.sh $f);\
 		install -m755 $f $$tgt;${call varsubst,$$tgt};)
 	$(foreach f,${SHELLLIBS},install -m644 $f ${SHARE_DIR})
 	$(foreach f,${UDEVRULES},install -m644 $f ${UDEVDIR};)
 	$(foreach f,$(wildcard systemd/network/*.network),install -m644 $f ${SYSTEMD_NETWORK_DIR};)
 	$(foreach f,$(wildcard systemd/system/*.service systemd/system/*.timer),install -m644 $f ${SYSTEMD_SYSTEM_DIR};)
-	$(foreach f,${SYSCTL_FILES},install -m644 $f ${SYSCTL_DIR})
 
 .PHONY: check
 check: ## Run tests

--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -25,13 +25,11 @@ to manage network configuration in the Amazon EC2 cloud environment
 make install DESTDIR=%{buildroot} PREFIX=/usr
 
 %files
-%{_sysconfdir}/sysctl.d/90-ipv6-dad.conf
 /usr/lib/systemd/network/80-ec2.network
 /usr/lib/systemd/system/policy-routes@.service
 /usr/lib/systemd/system/refresh-policy-routes@.service
 /usr/lib/systemd/system/refresh-policy-routes@.timer
 
-/usr/lib/udev/rules.d/98-eni.rules
 /usr/lib/udev/rules.d/99-vpc-policy-routes.rules
 %{_bindir}/setup-policy-routes
 %{_datarootdir}/amazon-ec2-net-utils/lib.sh

--- a/debian/dirs
+++ b/debian/dirs
@@ -3,4 +3,3 @@
 /usr/lib/udev/rules.d
 /usr/lib/systemd/system
 /usr/lib/systemd/network
-/etc/sysctl.d

--- a/udev/98-eni.rules
+++ b/udev/98-eni.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="net", ACTION=="add", ENV{ID_NET_DRIVER}=="vif|ena|ixgbevf", RUN+="/sbin/sysctl -w net.ipv6.conf.$name.accept_dad=0"


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

We were previously disabling IPv6 Duplicate Address Discovery (DAD, unnecessary in AWS VPC networks), using a sysctl config fragment and explicit sysctl from udev rules.  However this same operation is performed in the ENI default .network file, rendering these other mechanisms redundant.  So we delete them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
