### PR TITLE
Route configuration cleanup

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -235,7 +235,7 @@ create_if_overrides() {
 
     local cfgdir="${cfgfile}.d"
     local dropin="${cfgdir}/eni.conf"
-    local -i metric=$((metric_base+ifid))
+    local -i metric=$((metric_base+10*ifid))
     local -i tableid=0
     if [ $ifid -gt 0 ]; then
         tableid=$((rule_base+ifid))

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -252,28 +252,28 @@ DHCP=yes
 RouteMetric=${metric}
 [DHCPv6]
 RouteMetric=${metric}
-[Route]
-Table=${tableid}
-Gateway=_ipv6ra
 EOF
 
     if [ "$tableid" -gt 0 ]; then
         cat <<EOF >> "${dropin}.tmp"
+[Route]
+Table=${tableid}
+Gateway=_ipv6ra
 [DHCPv4]
 RouteTable=${tableid}
 [IPv6AcceptRA]
 RouteTable=${tableid}
 EOF
-    fi
-
-    if subnet_supports_ipv4 "$iface"; then
-        # if we're not in a v6-only network, add IPv4 routes to the private table
-        cat <<EOF >> "${dropin}.tmp"
+	if subnet_supports_ipv4 "$iface"; then
+            # if we're not in a v6-only network, add IPv4 routes to the private table
+            cat <<EOF >> "${dropin}.tmp"
 [Route]
 Gateway=_dhcp4
 Table=${tableid}
 EOF
+	fi
     fi
+
     mv "${dropin}.tmp" "$dropin"
     echo 1
 }


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

This change contains two minor fixes to our routing configuration:
1. Leave a gap in the route metrics for each interface. This gives the option to override our configuration with custom routing, if that should be desirable for some reason.
2. Don't install unnecessary route configuration for the main table. Because we're no longer creating a device-specific table for the "primary" interface, we don't need to define custom routing; the systemd-networkd defaults will use the main table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
