### PR TITLE
Finalize release 2.3.0

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
 pkgname=amazon-ec2-net-utils
-version=2.2.0
+version=2.3.0
 
 # Used by 'install'
 PREFIX?=/usr/local

--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -1,5 +1,5 @@
 Name:    amazon-ec2-net-utils
-Version: 2.2.0
+Version: 2.3.0
 Release: 1%{?dist}
 Summary: utilities for managing network interfaces in Amazon EC2
 

--- a/bin/setup-policy-routes.sh
+++ b/bin/setup-policy-routes.sh
@@ -29,8 +29,6 @@ iface="$1"
 
 mkdir -p "$runtimeroot"
 
-get_token
-
 case "$2" in
 stop)
     register_networkd_reloader

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+amazon-ec2-net-utils (2.3.0-1~1) unstable; urgency=medium
+
+  * New upstream release
+
+ -- Noah Meyerhans <nmeyerha@amazon.com>  Mon, 10 Oct 2022 15:52:58 -0700
+
 amazon-ec2-net-utils (2.2.0-1~1) unstable; urgency=medium
 
   * New upstream release

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -38,7 +38,7 @@ get_token() {
     while [ "$(date +%s)" -lt $deadline ]; do
         for ep in "${imds_endpoints[@]}"; do
             set +e
-            imds_token=$(curl --connect-timeout 0.15 -s --fail \
+            imds_token=$(curl --max-time 5 --connect-timeout 0.15 -s --fail \
                               -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" ${ep}/${imds_token_path})
             set -e
             if [ -n "$imds_token" ]; then
@@ -83,7 +83,7 @@ get_meta() {
     local url="${imds_endpoint}/meta-data/${key}"
     local meta rc
     while [ $attempts -lt $max_tries ]; do
-        meta=$(curl -s -H "X-aws-ec2-metadata-token:${imds_token}" -f "$url")
+        meta=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token:${imds_token}" -f "$url")
         rc=$?
         if [ $rc -eq 0 ]; then
             echo "$meta"

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -78,6 +78,8 @@ get_meta() {
     declare -i attempts=0
     debug "[get_meta] Querying IMDS for ${key}"
 
+    get_token
+
     local url="${imds_endpoint}/meta-data/${key}"
     local meta rc
     while [ $attempts -lt $max_tries ]; do


### PR DESCRIPTION
*Description of changes:*

This PR contains two minor code changes in addition to the new release metadata:

1. Move the `get_token` call (IMDSv2 token retrieval) to the get_meta function, such that it's only called if we actually need a token
2. Set a 5s max-time value for all `curl` calls. In normal scenarios we expect curl to complete far faster than that, but we don't want to be _too_ aggressive about bailing out in case the instance is heavily loaded and thus not underperforming.

Bump version to 2.3.0 in GNUMakefile and package metadata

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
