### PR TITLE
Improve lockfile handling and cleanup

### DIFF
--- a/systemd/system/policy-routes@.service
+++ b/systemd/system/policy-routes@.service
@@ -12,6 +12,8 @@ NoNewPrivileges=yes
 User=root
 Environment="EC2_IF_INITIAL_SETUP=true"
 ExecStart=/usr/bin/setup-policy-routes %i start
+ExecStartPost=/usr/bin/setup-policy-routes %i cleanup
 ExecStop=/usr/bin/setup-policy-routes %i stop
+ExecStopPost=/usr/bin/setup-policy-routes %i cleanup
 Restart=on-failure
 RestartSec=1

--- a/systemd/system/refresh-policy-routes@.service
+++ b/systemd/system/refresh-policy-routes@.service
@@ -8,4 +8,5 @@ AmbientCapabilities=CAP_NET_ADMIN
 NoNewPrivileges=yes
 User=root
 ExecStart=/usr/bin/setup-policy-routes %i start
+ExecStartPost=/usr/bin/setup-policy-routes %i cleanup
 SuccessExitStatus=SIGTERM


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

This change is intended to add additional protections against situations in which the lock file is not deleted upon program exit. If that happened previously, then future invocations of the setup-policy-routes for any interface would fail to reload networkd.

With this change, we execute a cleanup function using a systemd ExecStartPost or ExecStopPost, whichever is appropriate, to remove a lock file for a given interface when the setup-policy-routes job is complete.

Note that this change is a superset of #78, and merging it will merge those changes as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
