### PR TITLE
Preserve route config file across ifdown/ifup cycles

### DIFF
--- a/50_ec2_rewrite_primary_enter_hook.sh
+++ b/50_ec2_rewrite_primary_enter_hook.sh
@@ -61,16 +61,18 @@ ec2_rewrite_primary_enter_hook() {
     [ -z "$gateway" ] && { logger --tag ec2net "DHCP lease did not set gateway" ; return 1; }
     [ -z "$route_dest" ] && { logger --tag ec2net "DHCP lease did not set route_dest" ; return 1; }
 
-    if subnet_supports_ipv4 "$new_ip_address"; then
-        cat << EOF > ${route_file}
+    if [ ! -f "${route_file}" ]; then
+        if subnet_supports_ipv4 "$new_ip_address"; then
+            cat << EOF > ${route_file}
 default via ${gateway} dev ${interface} table ${RTABLE}
 ${route_dest} dev ${interface} proto kernel scope link src ${new_ip_address} table ${RTABLE}
 EOF
-        if should_use_mainroutetable "$config_file"; then
-            logger --tag ec2net "[dhclient] adding default route to main table for ${interface} metric ${RTABLE}"
-            cat << EOF >> ${route_file}
+            if should_use_mainroutetable "$config_file"; then
+                logger --tag ec2net "[dhclient] adding default route to main table for ${interface} metric ${RTABLE}"
+                cat << EOF >> ${route_file}
 default via ${gateway} dev ${interface} metric ${RTABLE}
 EOF
+            fi
         fi
     fi
 }

--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -6,7 +6,7 @@
 
 Name:      amazon-ec2-net-utils
 Summary:   A set of network tools for managing ENIs
-Version:   1.7.2
+Version:   1.7.3
 Release:   1%{?dist}
 License:   MIT and GPLv2
 
@@ -26,7 +26,7 @@ Requires: systemd-units
 %endif # systemd
 Requires: dhclient >= 4.2.5-77.amzn2.1.5
 Provides: ec2-net-utils = %{version}-%{release}
-Obsoletes: ec2-net-utils < 1.7.2
+Obsoletes: ec2-net-utils < 1.7.3
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %description
@@ -89,6 +89,9 @@ rm -rf $RPM_BUILD_ROOT
 %doc %{_mandir}/man8/ec2ifscan.8.gz
 
 %changelog
+* Tue Oct 25 2022 Noah Meyerhans <nmeyerha@amazon.com> 1.7.3-1.amzn2
+- Do not delete route-ethX files on ifup
+
 * Thu Oct  6 2022 Noah Meyerhans <nmeyerha@amazon.com> 1.7.2-1.amzn2
 - Update to upstream release 1.7.2
 - Fix management of policy rules for IPv6 PD prefixes

--- a/ec2net-functions
+++ b/ec2net-functions
@@ -294,12 +294,7 @@ rewrite_primary() {
 	MAINROUTETABLE=${MAINROUTETABLE}
 EOF
 
-  # We would normally write to ${route6_file} here but the
-  # gateway is an fe80:: link local address that we get from the
-  # RA. We only get an RA if the interface has an IPv6 address.
-  # So we wait until dhclient -6 runs rewrite_rules() and add the
-  # ${RTABLE} table there.
-  rm -f ${route6_file}
+  rm -f "${route6_file}" "${route_file}"
 
   # Use broadcast address instead of unicast dhcp server address.
   # Works around an issue with two interfaces on the same subnet.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,6 +32,7 @@ define compare-outputs
   $(foreach t,${SCRIPTS},
     $(call compare-output,${1},${t})
   )
+  rm -rf "${OUTPUTDIR}/${1}"
 endef
 
 define compare-output

--- a/tests/tdata/secondary-basic/ec2ifup.out
+++ b/tests/tdata/secondary-basic/ec2ifup.out
@@ -1,5 +1,5 @@
 CALLED logger --tag ec2net [plug_interface] eth1 plugged
 CALLED logger --tag ec2net [rewrite_primary] Rewriting configs for eth1
-CALLED rm -f ./test-output/secondary-basic/etc/sysconfig/network-scripts/route6-eth1
+CALLED rm -f ./test-output/secondary-basic/etc/sysconfig/network-scripts/route6-eth1 ./test-output/secondary-basic/etc/sysconfig/network-scripts/route-eth1
 CALLED logger --tag ec2net [activate_primary] Activating eth1
 CALLED ifup eth1

--- a/tests/tdata/secondary-delegated-v4/ec2ifup.out
+++ b/tests/tdata/secondary-delegated-v4/ec2ifup.out
@@ -1,5 +1,5 @@
 CALLED logger --tag ec2net [plug_interface] eth2 plugged
 CALLED logger --tag ec2net [rewrite_primary] Rewriting configs for eth2
-CALLED rm -f ./test-output/secondary-delegated-v4/etc/sysconfig/network-scripts/route6-eth2
+CALLED rm -f ./test-output/secondary-delegated-v4/etc/sysconfig/network-scripts/route6-eth2 ./test-output/secondary-delegated-v4/etc/sysconfig/network-scripts/route-eth2
 CALLED logger --tag ec2net [activate_primary] Activating eth2
 CALLED ifup eth2

--- a/tests/tdata/secondary-delegated-v6/ec2ifup.out
+++ b/tests/tdata/secondary-delegated-v6/ec2ifup.out
@@ -1,5 +1,5 @@
 CALLED logger --tag ec2net [plug_interface] eth2 plugged
 CALLED logger --tag ec2net [rewrite_primary] Rewriting configs for eth2
-CALLED rm -f ./test-output/secondary-delegated-v6/etc/sysconfig/network-scripts/route6-eth2
+CALLED rm -f ./test-output/secondary-delegated-v6/etc/sysconfig/network-scripts/route6-eth2 ./test-output/secondary-delegated-v6/etc/sysconfig/network-scripts/route-eth2
 CALLED logger --tag ec2net [activate_primary] Activating eth2
 CALLED ifup eth2

--- a/tests/tdata/secondary-more-ips/ec2ifup.out
+++ b/tests/tdata/secondary-more-ips/ec2ifup.out
@@ -1,5 +1,5 @@
 CALLED logger --tag ec2net [plug_interface] eth2 plugged
 CALLED logger --tag ec2net [rewrite_primary] Rewriting configs for eth2
-CALLED rm -f ./test-output/secondary-more-ips/etc/sysconfig/network-scripts/route6-eth2
+CALLED rm -f ./test-output/secondary-more-ips/etc/sysconfig/network-scripts/route6-eth2 ./test-output/secondary-more-ips/etc/sysconfig/network-scripts/route-eth2
 CALLED logger --tag ec2net [activate_primary] Activating eth2
 CALLED ifup eth2

--- a/tests/tdata/secondary-multiple-delegated-v4/ec2ifup.out
+++ b/tests/tdata/secondary-multiple-delegated-v4/ec2ifup.out
@@ -1,5 +1,5 @@
 CALLED logger --tag ec2net [plug_interface] eth2 plugged
 CALLED logger --tag ec2net [rewrite_primary] Rewriting configs for eth2
-CALLED rm -f ./test-output/secondary-multiple-delegated-v4/etc/sysconfig/network-scripts/route6-eth2
+CALLED rm -f ./test-output/secondary-multiple-delegated-v4/etc/sysconfig/network-scripts/route6-eth2 ./test-output/secondary-multiple-delegated-v4/etc/sysconfig/network-scripts/route-eth2
 CALLED logger --tag ec2net [activate_primary] Activating eth2
 CALLED ifup eth2

--- a/tests/tdata/secondary-multiple-delegated-v6/ec2ifup.out
+++ b/tests/tdata/secondary-multiple-delegated-v6/ec2ifup.out
@@ -1,5 +1,5 @@
 CALLED logger --tag ec2net [plug_interface] eth2 plugged
 CALLED logger --tag ec2net [rewrite_primary] Rewriting configs for eth2
-CALLED rm -f ./test-output/secondary-multiple-delegated-v6/etc/sysconfig/network-scripts/route6-eth2
+CALLED rm -f ./test-output/secondary-multiple-delegated-v6/etc/sysconfig/network-scripts/route6-eth2 ./test-output/secondary-multiple-delegated-v6/etc/sysconfig/network-scripts/route-eth2
 CALLED logger --tag ec2net [activate_primary] Activating eth2
 CALLED ifup eth2

--- a/tests/tdata/v6-uncompressed-prefixes/ec2ifup.out
+++ b/tests/tdata/v6-uncompressed-prefixes/ec2ifup.out
@@ -1,5 +1,5 @@
 CALLED logger --tag ec2net [plug_interface] eth2 plugged
 CALLED logger --tag ec2net [rewrite_primary] Rewriting configs for eth2
-CALLED rm -f ./test-output/v6-uncompressed-prefixes/etc/sysconfig/network-scripts/route6-eth2
+CALLED rm -f ./test-output/v6-uncompressed-prefixes/etc/sysconfig/network-scripts/route6-eth2 ./test-output/v6-uncompressed-prefixes/etc/sysconfig/network-scripts/route-eth2
 CALLED logger --tag ec2net [activate_primary] Activating eth2
 CALLED ifup eth2


### PR DESCRIPTION
*Issue #, if available:* 

#82 

*Description of changes:*

Fix a regression from 1.6 and earlier in which `ifup ethX` results in the removal of any local modifications made to `/etc/sysconfig/network-scripts/route-ethX`.  The file should be regenerated wtih `ec2ifup`, which is invoked on hotplug, but not `ifup`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
