### PR TITLE
Fix directory ownership in spec file

### DIFF
--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -1,6 +1,6 @@
 Name:    amazon-ec2-net-utils
 Version: 2.3.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: utilities for managing network interfaces in Amazon EC2
 
 License: Apache 2.0
@@ -32,6 +32,7 @@ make install DESTDIR=%{buildroot} PREFIX=/usr
 
 /usr/lib/udev/rules.d/99-vpc-policy-routes.rules
 %{_bindir}/setup-policy-routes
+%dir %{_datarootdir}/amazon-ec2-net-utils
 %{_datarootdir}/amazon-ec2-net-utils/lib.sh
 
 %post


### PR DESCRIPTION
The entire /usr/share/amazon-ec2-net-utils directory should be owned by the amazon-ec2-net-utils package, not just the files inside of it.

This change corrects the spec file to assign ownership of the directory to the package.

*Issue #84 

*Description of changes:*
The change adds directory ownership to the `amazon-ec2-net-utils package.` 

Testing a build and installation on an AL2022 instance:

```
[ec2-user@ip-172-16-3-183 ~]$ rpm -qf /usr/share/amazon-ec2-net-utils/
file /usr/share/amazon-ec2-net-utils is not owned by any package
[ec2-user@ip-172-16-3-183 ~]$ rpm -qf /usr/share/amazon-ec2-net-utils/lib.sh 
amazon-ec2-net-utils-2.3.0-1.amzn2022.0.1.noarch
[ec2-user@ip-172-16-3-183 ~]$ sudo dnf localinstall amazon-ec2-net-utils-2.3.0-2.amzn2022.noarch.rpm
Last metadata expiration check: 0:03:06 ago on Fri 04 Nov 2022 08:13:51 PM UTC.
Dependencies resolved.
=====================================================================================================================================================================================================
 Package                                               Architecture                            Version                                           Repository                                     Size
=====================================================================================================================================================================================================
Upgrading:
 amazon-ec2-net-utils                                  noarch                                  2.3.0-2.amzn2022                                  @commandline                                   14 k

Transaction Summary
=====================================================================================================================================================================================================
Upgrade  1 Package

Total size: 14 k
Is this ok [y/N]: y
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                             1/1 
  Upgrading        : amazon-ec2-net-utils-2.3.0-2.amzn2022.noarch                                                                                                                                1/2 
  Running scriptlet: amazon-ec2-net-utils-2.3.0-2.amzn2022.noarch                                                                                                                                1/2 
  Cleanup          : amazon-ec2-net-utils-2.3.0-1.amzn2022.0.1.noarch                                                                                                                            2/2 
  Running scriptlet: amazon-ec2-net-utils-2.3.0-1.amzn2022.0.1.noarch                                                                                                                            2/2 
  Verifying        : amazon-ec2-net-utils-2.3.0-2.amzn2022.noarch                                                                                                                                1/2 
  Verifying        : amazon-ec2-net-utils-2.3.0-1.amzn2022.0.1.noarch                                                                                                                            2/2 

Upgraded:
  amazon-ec2-net-utils-2.3.0-2.amzn2022.noarch                                                                                                                                                       

Complete!
[ec2-user@ip-172-16-3-183 ~]$ rpm -qf /usr/share/amazon-ec2-net-utils/
amazon-ec2-net-utils-2.3.0-2.amzn2022.noarch
[ec2-user@ip-172-16-3-183 ~]$ rpm -qf /usr/share/amazon-ec2-net-utils/lib.sh 
amazon-ec2-net-utils-2.3.0-2.amzn2022.noarch
```
The host also reboots successfully after the upgrade and can be accessed via SSH.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
