### PR TITLE
Fix shellcheck SC2320 warning

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -394,11 +394,12 @@ maybe_reload_networkd() {
 }
 
 register_networkd_reloader() {
-    local -i registered=1
-    while [ $registered -ne 0 ]; do
+    local -i registered=0
+    while [ $registered -eq 0 ]; do
         mkdir -p "$lockdir"
         trap 'debug "Called trap" ; maybe_reload_networkd' EXIT
-        echo $$ > "${lockdir}/${iface}"
-        registered=$?
+        if echo $$ > "${lockdir}/${iface}"; then
+            registered=1
+        fi
     done
 }


### PR DESCRIPTION
*Issue:* #88 

*Description of changes:*

Current versions of shellcheck complain about code like

```sh
echo $$ > /tmp/foo
result=$?
```

The intent is to set result to 0 if the redirect is successful, or nonzero if it fails.

The recommendation is to wrap the echo and redirect in an `if` conditional, so that's what we do here.

See https://www.shellcheck.net/wiki/SC2320

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
