### PR TITLE
Add scratch-rpm makefile target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,8 +16,6 @@ UDEVRULES=$(wildcard udev/*.rules)
 
 DIRS:=${BINDIR} ${UDEVDIR} ${SYSTEMDDIR} ${SYSTEMD_SYSTEM_DIR} ${SYSTEMD_NETWORK_DIR} ${SHARE_DIR}
 
-DIST_TARGETS=dist-xz dist-gz
-
 .PHONY: help
 help: ## show help
 	@egrep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -44,8 +42,16 @@ check: ## Run tests
 		shellcheck --severity warning $${script};\
 	done
 
+.PHONY: scratch-rpm
+scratch-rpm: source_version_suffix=$(shell git describe --dirty --tags | sed "s,^v${version},,")
+scratch-rpm: rpm_version_suffix=$(shell git describe --dirty --tags | sed "s,^v${version},,; s,-,.,g")
+scratch-rpm: scratch-sources
+scratch-rpm: ## build an RPM based on the current working copy
+	rpmbuild -D "_sourcedir $(CURDIR)/.." -D "_source_version_suffix ${source_version_suffix}" \
+	         -D "_rpm_version_suffix ${rpm_version_suffix}" -bb amazon-ec2-net-utils.spec
+
 .PHONY: scratch-sources
-scratch-sources: version=$(shell git describe --dirty --tags)
+scratch-sources: version=$(shell git describe --dirty --tags | sed "s,^v,,")
 scratch-sources: ## generate a tarball based on the current working copy
 	tar czf ../${pkgname}-${version}.tar.gz --exclude=.git --transform 's,^./,./${pkgname}-${version}/,' .
 
@@ -64,6 +70,7 @@ head-check:
 	@if ! git diff --name-only --exit-code v${version} HEAD > /dev/null; then \
 		echo "*** ERROR: Git checkout not at version ${version}"; exit 1; fi ; \
 
-tag: uncommitted-check version-check ## Tag a new release
+tag: uncommitted-check ## Tag a new release
 	@if git rev-parse --verify v$(version) > /dev/null 2>&1; then \
-		echo "*** ERROR: Version $(VERSION) is already tagged"; exit 1; fi
+		echo "*** ERROR: Version $(version) is already tagged"; exit 1; fi
+	git tag v${version}

--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -1,11 +1,13 @@
 Name:    amazon-ec2-net-utils
-Version: 2.3.0
+%define  base_version 2.3.0
+%define  source_version %{base_version}%{?_source_version_suffix}
+Version: %{base_version}%{?_rpm_version_suffix}
 Release: 1%{?dist}
 Summary: utilities for managing network interfaces in Amazon EC2
 
 License: Apache 2.0
 URL:     https://github.com/aws/amazon-ec2-net-utils/
-Source0: amazon-ec2-net-utils-%{version}.tar.gz
+Source0: amazon-ec2-net-utils-%{source_version}.tar.gz
 
 BuildArch: noarch
 
@@ -19,7 +21,7 @@ to manage network configuration in the Amazon EC2 cloud environment
 
 %prep
 
-%autosetup -n %{name}-%{version}
+%autosetup -n %{name}-%{source_version}
 
 %install
 make install DESTDIR=%{buildroot} PREFIX=/usr


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

I've found it convenient when developing this package to be able to quickly generate an rpm based on an unreleased branch.  So, this change a scratch-rpm makefile target that does just this.

```
[ec2-user@ip-10-0-1-138 amazon-ec2-net-utils]$ make scratch-rpm
tar czf ../amazon-ec2-net-utils-2.3.0-5-g3d64d70.tar.gz --exclude=.git --transform 's,^./,./amazon-ec2-net-utils-2.3.0-5-g3d64d70/,' .
rpmbuild -D "_sourcedir /home/ec2-user/amazon-ec2-net-utils/.." -D "_source_version_suffix -5-g3d64d70" \
         -D "_rpm_version_suffix .5.g3d64d70" -bb amazon-ec2-net-utils.spec
...
Wrote: /home/ec2-user/rpmbuild/RPMS/noarch/amazon-ec2-net-utils-2.3.0.5.g3d64d70-1.amzn2023.noarch.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.IMmBGI
+ umask 022
+ cd /home/ec2-user/rpmbuild/BUILD
+ cd amazon-ec2-net-utils-2.3.0-5-g3d64d70
+ /usr/bin/rm -rf /home/ec2-user/rpmbuild/BUILDROOT/amazon-ec2-net-utils-2.3.0.5.g3d64d70-1.amzn2023.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
