### PR TITLE
route configuration cleanup and fixes

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -35,12 +35,13 @@ get_token() {
     # invocations we avoid retrying
     local deadline
     deadline=$(date -d "now+30 seconds" +%s)
+    local old_opts=$-
     while [ "$(date +%s)" -lt $deadline ]; do
         for ep in "${imds_endpoints[@]}"; do
             set +e
             imds_token=$(curl --max-time 5 --connect-timeout 0.15 -s --fail \
                               -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" ${ep}/${imds_token_path})
-            set -e
+            [[ $old_opts = *e* ]] && set -e
             if [ -n "$imds_token" ]; then
                 debug "Got IMDSv2 token from ${ep}"
                 imds_endpoint=$ep

--- a/systemd/network/80-ec2.network
+++ b/systemd/network/80-ec2.network
@@ -21,10 +21,3 @@ UseHostname=no
 UseDNS=yes
 UseNTP=yes
 WithoutRA=solicit
-
-[Route]
-Gateway=_ipv6ra
-
-[IPv6AcceptRA]
-UseDomains=yes
-


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

This change adds a rule for ENI traffic egressing with the primary NIC's address in the source field. This was left out previously in keeping with AL2's behavior, but leads to traffic loss.

Test results will follow in the comments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
