### PR TITLE
add support for nonzero network-card IMDS values

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -199,14 +199,15 @@ subnet_prefixroutes() {
 
 create_rules() {
     local iface=$1
-    local ifid=$2
-    local family=$3
+    local device_number=$2
+    local network_card=$3
+    local family=$4
     local addrs prefixes
     local local_addr_key subnet_pd_key
     local drop_in_dir="${unitdir}/70-${iface}.network.d"
     mkdir -p "$drop_in_dir"
 
-    local -i ruleid=$((ifid+rule_base))
+    local -i ruleid=$((device_number+rule_base+100*network_card))
 
     case $family in
         4)
@@ -258,14 +259,15 @@ EOF
 
 create_if_overrides() {
     local iface="$1"; test -n "$iface" || { echo "Invalid iface at $LINENO" >&2 ; exit 1; }
-    local ifid="$2"; test -n "$ifid" || { echo "Invalid ifid at $LINENO" >&2 ; exit 1; }
-    local ether="$3"; test -n "$ether" || { echo "Invalid ether at $LINENO" >&2 ; exit 1; }
-    local cfgfile="$4"; test -n "$cfgfile" || { echo "Invalid cfgfile at $LINENO" >&2 ; exit 1; }
+    local -i device_number="$2"; test -n "$device_number" || { echo "Invalid device_number at $LINENO" >&2 ; exit 1; }
+    local -i network_card="$3"; test -n "$network_card" || { echo "Invalid network_card at $LINENO" >&2 ; exit 1; }
+    local ether="$4"; test -n "$ether" || { echo "Invalid ether at $LINENO" >&2 ; exit 1; }
+    local cfgfile="$5"; test -n "$cfgfile" || { echo "Invalid cfgfile at $LINENO" >&2 ; exit 1; }
 
     local cfgdir="${cfgfile}.d"
     local dropin="${cfgdir}/eni.conf"
-    local -i metric=$((metric_base+10*ifid))
-    local -i tableid=$((rule_base+ifid))
+    local -i metric=$((metric_base+100*network_card+device_number))
+    local -i tableid=$((rule_base+100*network_card+device_number))
 
     mkdir -p "$cfgdir"
     cat <<EOF > "${dropin}.tmp"
@@ -326,9 +328,10 @@ EOF
 add_altnames() {
     local iface=$1
     local ether=$2
-    local eni_id device_number
+    local device_number=$3
+    local network_card=$4
+    local eni_id
     eni_id=$(get_iface_imds "$ether" interface-id)
-    device_number=$(get_iface_imds "$ether" device-number)
     # Interface altnames can also be added using systemd .link files.
     # However, in order to use them, we need to wait until a
     # systemd-networkd reload operation completes and then trigger a
@@ -338,16 +341,26 @@ add_altnames() {
            ! ip link show dev "$iface" | grep -q -E "altname\s+${eni_id}"; then
         ip link property add dev "$iface" altname "$eni_id" || true
     fi
+    local device_number_alt="device-number-${device_number}"
+    if [ -n "$network_card" ]; then
+        # On instance types that don't support a network-card key, we
+        # won't append a value here.  A value of zero would be
+        # appropriate, but would be a visible change to the interface
+        # configuration on these instance types and could disrupt
+        # existing automation.
+        device_number_alt="${device_number_alt}.${network_card}"
+    fi
     if [ -n "$device_number" ] &&
-           ! ip link show dev "$iface" | grep -q -E "altname\s+device-number"; then
-        ip link property add dev "$iface" altname "device-number-${device_number}" || true
+           ! ip link show dev "$device_number_alt" > /dev/null 2>&1; then
+        ip link property add dev "$iface" altname "${device_number_alt}" || true
     fi
 }
 
 create_interface_config() {
     local iface=$1
-    local ifid=$2
-    local ether=$3
+    local device_number=$2
+    local network_card=$3
+    local ether=$4
 
     local libdir=/usr/lib/systemd/network
     local defconfig="${libdir}/80-ec2.network"
@@ -364,8 +377,8 @@ create_interface_config() {
     debug "Linking $cfgfile to $defconfig"
     mkdir -p "$unitdir"
     ln -s "$defconfig" "$cfgfile"
-    retval+=$(create_if_overrides "$iface" "$ifid" "$ether" "$cfgfile")
-    add_altnames "$iface" "$ether"
+    retval+=$(create_if_overrides "$iface" "$device_number" "$network_card" "$ether" "$cfgfile")
+    add_altnames "$iface" "$ether" "$device_number" "$network_card"
     echo $retval
 }
 
@@ -405,6 +418,19 @@ _get_device_number() {
     return 1
 }
 
+# print the network-card IMDS value for the given interface
+# NOTE: On many instance types, this value is not defined.  This
+# function will print the empty string on those instances.  On
+# instances where it is defined, it will be a numeric value.
+_get_network_card() {
+    local iface ether network_card
+    iface="$1"
+    ether="$2"
+    network_card=$(get_iface_imds "$ether" network-card)
+    echo ${network_card}
+}
+
+
 # Interfaces get configured with addresses and routes from
 # DHCP. Routes are inserted in the main table with metrics based on
 # their physical location (slot ID) to ensure deterministic route
@@ -415,11 +441,12 @@ _get_device_number() {
 # interface-specific routing table.
 setup_interface() {
     local iface ether
-    local -i device_number
+    local -i device_number network_card
     iface=$1
     ether=$2
 
     device_number=$(_get_device_number "$iface" "$ether")
+    network_card=$(_get_network_card "$iface" "$ether")
 
     # Newly provisioned resources (new ENI attachments) take some
     # time to be fully reflected in IMDS. In that case, we poll
@@ -432,7 +459,7 @@ setup_interface() {
     while [ "$(date +%s)" -lt $deadline ]; do
         local -i changes=0
 
-        changes+=$(create_interface_config "$iface" "$device_number" "$ether")
+        changes+=$(create_interface_config "$iface" "$device_number" "$network_card" "$ether")
         for family in 4 6; do
             if [ $device_number -ne 0 ]; then
                 # We only create rules for secondary interfaces so
@@ -446,7 +473,7 @@ setup_interface() {
                 # they'll redirect the return traffic out ens5 rather
                 # than docker0, effectively blackholing it.
                 # https://github.com/amazonlinux/amazon-ec2-net-utils/issues/97
-                changes+=$(create_rules "$iface" "$device_number" $family)
+                changes+=$(create_rules "$iface" "$device_number" "$network_card" $family)
             fi
         done
         changes+=$(create_ipv4_aliases $iface $ether)


### PR DESCRIPTION
*Issue #, if available:* #104

*Description of changes:*

Add support for instance types that define a "network-card" interface key.  Most instance types do not support non-zero NetworkCardIndex API values.  On those, the network-card IMDS key is not defined and results in an HTTP 404.  Other instance types, such as c6in.32xlarge, allow the attachment of ENIs with non-zero `NetworkCardIndex` values.  Prior to this change, such configurations were not well supported, and could result in invalid or incomplete configuration.

With this change, the behavior on instance types that **do not** support non-zero `NetworkCardIndex` values is unchanged.  On instance types that **do** support non-zero values, there are several behavior changes:

1. The `device-number` altname on each interface reflects both the `device-number` and `network-card` values, formatted as `device-number-${device-number}.${network-card}`.  For example:
  * `device-number-0.0` for the first ENI
  *  `device-number-1.0` for device-number 1, network-card 0
  * `device-number-0.1` for device-number 0, network-card 1
2. Non-zero `network-card` values are accounted for in policy routing rules and route metrics.  Examples follow:

The output below shows the policy routing rules for an instance with additional ENIs having device-number/network-card 0/1 and 1/1.  The former is given rule priority 10001 and the latter is 10101:
```plain
[ec2-user@ip-10-0-1-184 ~]$ ip rule
0:      from all lookup local
10001:  from 10.0.1.204 lookup 10001 proto static
10101:  from 10.0.1.54 lookup 10101 proto static
32766:  from all lookup main
32767:  from all lookup default
```

The same instance has the following entries for the default route in the main table, indicating similar interface prioritization:
```plain
[ec2-user@ip-10-0-1-184 ~]$ ip ro show table main default
default via 10.0.1.1 dev ens5 proto dhcp src 10.0.1.184 metric 512 
default via 10.0.1.1 dev ens6 proto dhcp src 10.0.1.204 metric 513 
default via 10.0.1.1 dev ens7 proto dhcp src 10.0.1.54 metric 613 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
