### PR TITLE
don't reconfigure networkd on "stop"

### DIFF
--- a/debian/patches/update-networkd-priorities.patch
+++ b/debian/patches/update-networkd-priorities.patch
@@ -1,15 +1,31 @@
-From 7280ff5206eeed978d4b7f563475e5eba16babab Mon Sep 17 00:00:00 2001
+From 3c792705401188860d8c40fd192701696f77c43c Mon Sep 17 00:00:00 2001
 From: Noah Meyerhans <nmeyerha@amazon.com>
-Date: Wed, 6 Mar 2024 11:37:11 -0800
+Date: Thu, 7 Mar 2024 17:00:45 -0800
 Subject: [PATCH] change the priority of the networkd configs
 
 ensure they're order before netplan
 ---
- lib/lib.sh | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ bin/setup-policy-routes.sh | 4 ++--
+ lib/lib.sh                 | 6 +++---
+ 2 files changed, 5 insertions(+), 5 deletions(-)
 
+diff --git a/bin/setup-policy-routes.sh b/bin/setup-policy-routes.sh
+index a79fd09..9cb623b 100755
+--- a/bin/setup-policy-routes.sh
++++ b/bin/setup-policy-routes.sh
+@@ -62,8 +62,8 @@ remove)
+     register_networkd_reloader
+     info "Removing configuration for $iface."
+     rm -rf "/run/network/$iface" \
+-       "${unitdir}/70-${iface}.network" \
+-       "${unitdir}/70-${iface}.network.d" || true
++       "${unitdir}/07-${iface}.network" \
++       "${unitdir}/07-${iface}.network.d" || true
+     touch "$reload_flag"
+     ;;
+ stop|cleanup)
 diff --git a/lib/lib.sh b/lib/lib.sh
-index c9f1970..8933d7c 100644
+index 0a2ebc2..de3b00f 100644
 --- a/lib/lib.sh
 +++ b/lib/lib.sh
 @@ -151,7 +151,7 @@ create_ipv4_aliases() {
@@ -36,9 +52,9 @@ index c9f1970..8933d7c 100644
  
 -    local cfgfile="${unitdir}/70-${iface}.network"
 +    local cfgfile="${unitdir}/07-${iface}.network"
-     if [ -e "$cfgfile" ]; then
+     if [ -e "$cfgfile" ] &&
+            [ ! -v EC2_IF_INITIAL_SETUP ]; then
          debug "Using existing cfgfile ${cfgfile}"
-         echo $retval
 -- 
 2.25.1
 

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -374,7 +374,8 @@ create_interface_config() {
     local -i retval=0
 
     local cfgfile="${unitdir}/70-${iface}.network"
-    if [ -e "$cfgfile" ]; then
+    if [ -e "$cfgfile" ] &&
+           [ ! -v EC2_IF_INITIAL_SETUP ]; then
         debug "Using existing cfgfile ${cfgfile}"
         echo $retval
         return
@@ -382,7 +383,7 @@ create_interface_config() {
 
     debug "Linking $cfgfile to $defconfig"
     mkdir -p "$unitdir"
-    ln -s "$defconfig" "$cfgfile"
+    ln -sf "$defconfig" "$cfgfile"
     retval+=$(create_if_overrides "$iface" "$device_number" "$network_card" "$ether" "$cfgfile")
     add_altnames "$iface" "$ether" "$device_number" "$network_card"
     echo $retval

--- a/systemd/system/policy-routes@.service
+++ b/systemd/system/policy-routes@.service
@@ -10,10 +10,6 @@ PrivateTmp=yes
 AmbientCapabilities=CAP_NET_ADMIN
 NoNewPrivileges=yes
 User=root
-Environment="EC2_IF_INITIAL_SETUP=true"
 ExecStart=/usr/bin/setup-policy-routes %i start
-ExecStartPost=/usr/bin/setup-policy-routes %i cleanup
-ExecStop=/usr/bin/setup-policy-routes %i stop
-ExecStopPost=/usr/bin/setup-policy-routes %i cleanup
 Restart=on-failure
 RestartSec=1

--- a/systemd/system/policy-routes@.service
+++ b/systemd/system/policy-routes@.service
@@ -13,3 +13,4 @@ User=root
 ExecStart=/usr/bin/setup-policy-routes %i start
 Restart=on-failure
 RestartSec=1
+KillMode=process

--- a/systemd/system/policy-routes@.service
+++ b/systemd/system/policy-routes@.service
@@ -2,6 +2,10 @@
 Description=Set up policy routes for %I
 StartLimitIntervalSec=10
 StartLimitBurst=5
+Wants=refresh-policy-routes@%i.timer
+
+[Install]
+Also=refresh-policy-routes@%i.timer
 
 [Service]
 Type=oneshot

--- a/systemd/system/refresh-policy-routes@.service
+++ b/systemd/system/refresh-policy-routes@.service
@@ -7,6 +7,5 @@ PrivateTmp=yes
 AmbientCapabilities=CAP_NET_ADMIN
 NoNewPrivileges=yes
 User=root
-ExecStart=/usr/bin/setup-policy-routes %i start
-ExecStartPost=/usr/bin/setup-policy-routes %i cleanup
+ExecStart=/usr/bin/setup-policy-routes %i refresh
 SuccessExitStatus=SIGTERM

--- a/systemd/system/refresh-policy-routes@.service
+++ b/systemd/system/refresh-policy-routes@.service
@@ -9,3 +9,4 @@ NoNewPrivileges=yes
 User=root
 ExecStart=/usr/bin/setup-policy-routes %i refresh
 SuccessExitStatus=SIGTERM
+KillMode=process

--- a/udev/99-vpc-policy-routes.rules
+++ b/udev/99-vpc-policy-routes.rules
@@ -1,4 +1,2 @@
-SUBSYSTEM=="net", ACTION=="remove", ENV{ID_NET_DRIVER}=="vif|ena|ixgbevf", RUN+="/usr/bin/systemctl stop --no-block policy-routes@$name.service"
-SUBSYSTEM=="net", ACTION=="remove", ENV{ID_NET_DRIVER}=="vif|ena|ixgbevf", RUN+="/usr/bin/systemctl disable --now refresh-policy-routes@$name.timer refresh-policy-routes@$name.service policy-routes@$name.service"
-
+SUBSYSTEM=="net", ACTION=="remove", ENV{ID_NET_DRIVER}=="vif|ena|ixgbevf", RUN+="/usr/bin/systemctl disable --now refresh-policy-routes@$name.timer policy-routes@$name.service"
 SUBSYSTEM=="net", ACTION=="add", ENV{ID_NET_DRIVER}=="vif|ena|ixgbevf", RUN+="/usr/bin/systemctl enable --now --no-block policy-routes@$name.service refresh-policy-routes@$name.timer"

--- a/udev/99-vpc-policy-routes.rules
+++ b/udev/99-vpc-policy-routes.rules
@@ -1,2 +1,2 @@
 SUBSYSTEM=="net", ACTION=="remove", ENV{ID_NET_DRIVER}=="vif|ena|ixgbevf", RUN+="/usr/bin/systemctl disable --now refresh-policy-routes@$name.timer policy-routes@$name.service"
-SUBSYSTEM=="net", ACTION=="add", ENV{ID_NET_DRIVER}=="vif|ena|ixgbevf", RUN+="/usr/bin/systemctl enable --now --no-block policy-routes@$name.service refresh-policy-routes@$name.timer"
+SUBSYSTEM=="net", ACTION=="add", ENV{ID_NET_DRIVER}=="vif|ena|ixgbevf", RUN+="/usr/bin/systemctl enable --now --no-block policy-routes@$name.service"


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

This makes some changes to the behavior of ec2-net-utils when the `policy-routes` service is stopped.  The major change is that `stop` no longer removes the generated config.  This reduces the amount of work done and eliminates reloading of `systemd-networkd` when doing so provides no meaningful benefit.  Any routes and policy rules associated with an instance are deleted when an interface is removed, so the config removal is not meaningful.

This fixes an issue observed when stopping policy-routes@.service that would lead to forwarded connections (e.g. from a local Docker bridge network) to be flushed from the conntrack tables, leading to dropped packets.

There are other smaller changes to the systemd unit files:
* Set KillMode to only signal the top-level process, rather than the default behavior of signalling all processes in the cgroup
* Add Wants= and Also= relationships between policy-routes@.service and refresh-policy-routes@.timer units to clarify the relationship. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
