### PR TITLE
Revert changes made to implement backoff in case of IMDS missing data

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -81,7 +81,7 @@ error() {
 get_meta() {
     local key=$1
     local max_tries=${2:-10}
-    local -i attempts=0 ms_per_backoff=100 backoff=0
+    declare -i attempts=0
     debug "[get_meta] Querying IMDS for ${key}"
 
     get_token
@@ -96,8 +96,6 @@ get_meta() {
             return 0
         fi
         attempts+=1
-        backoff=$((attempts*ms_per_backoff))
-        sleep $((backoff/1000)).$((backoff%1000))
     done
     return 1
 }

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -95,13 +95,9 @@ get_meta() {
             echo "$meta"
             return 0
         fi
-        if [ ! -v EC2_IF_INITIAL_SETUP ]; then
-            return 1
-        else
-            attempts+=1
-            backoff=$((attempts*ms_per_backoff))
-            sleep $((backoff/1000)).$((backoff%1000))
-        fi
+        attempts+=1
+        backoff=$((attempts*ms_per_backoff))
+        sleep $((backoff/1000)).$((backoff%1000))
     done
     return 1
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amazonlinux/amazon-ec2-net-utils/issues/108

*Description of changes:*  It was identified that the backoff implementation for missing data of IMDS was causing an intermittent issue during the boot process of EC2 instances. This backoff time is causing the `networkctl reload` to occur late in the boot process. This situation creates a race condition where if `networkctl reload` occurs before cloud-init and system service start-up scripts, the instance launches successfully. However, if `networkctl reload` occurs during the execution of any of these processes, it results in a failure.

The current resolution is to revert these commits and release a minor version update. Moving forward, the next steps involve identifying an alternative approach to implement this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
