### PR TITLE
automatically allocate secondary ip address on assignment

### DIFF
--- a/bin/setup-policy-routes.sh
+++ b/bin/setup-policy-routes.sh
@@ -42,6 +42,7 @@ do_setup() {
 
 case "$2" in
 refresh)
+    register_networkd_reloader
     [ -e "/sys/class/net/${iface}" ] || exit 0
     info "Starting configuration refresh for $iface"
     do_setup


### PR DESCRIPTION
ec2-net-utils is expected to automatically assign secondary IP addresses when the ec2 assigned-private-ip-addresses api call is run. It is expected to refresh from the instance metadata service on at a regular interval and allocate the secondary ip address.

This is not currently happening, ec2-net-utils does appear to reach out to imds successfully but does not assign the secondary ip until network services have been restarted.

This adds a missing call to register_networkd_reloader in refresh to automatically allocate assigned IP addresses.
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
