### PR TITLE
Change "Waiting for sysfs node to exist" log message

### DIFF
--- a/bin/setup-policy-routes.sh
+++ b/bin/setup-policy-routes.sh
@@ -48,9 +48,13 @@ refresh)
     ;;
 start)
     register_networkd_reloader
+    counter=0
     while [ ! -e "/sys/class/net/${iface}" ]; do
-        debug  "Waiting for sysfs node to exist"
+        if ((counter % 1000 == 0)); then
+            debug "Waiting for sysfs node to exist for ${iface} (iteration $counter)"
+        fi
         sleep 0.1
+        ((counter++))
     done
     info "Starting configuration for $iface"
     debug /lib/systemd/systemd-networkd-wait-online -i "$iface"


### PR DESCRIPTION
*Description of changes:*

Change "Waiting for sysfs node to exist" log message

- now includes the interface it is waiting for.
- only logs once every 1,000 iterations of this loop, to reduce log noise in the case that it gets stuck in a loop. This corresponds to one log message about every 2 minutes.
- includes iteration counter for debugging long-running loops.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
