### PR TITLE
Adding user-agent to IMDS requests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,5 @@
 pkgname=amazon-ec2-net-utils
-version=2.6.0
+version=2.7.0
 
 # Used by 'install'
 PREFIX?=/usr/local
@@ -26,12 +26,16 @@ ${DIRS}:
 define varsubst
 sed -i "s,AMAZON_EC2_NET_UTILS_LIBDIR,${PREFIX}/share/${pkgname},g" $1
 endef
+define varsubstlibs
+sed -i "s,AMAZON_EC2_NET_UTILS_VERSION,${version},g" $1
+endef
 
 .PHONY: install
 install: ${SHELLSCRIPTS} ${UDEVRULES} ${SHELLLIBS} | ${DIRS} ## Install the software. Respects DESTDIR
 	$(foreach f,${SHELLSCRIPTS},tgt=${BINDIR}/$$(basename --suffix=.sh $f);\
 		install -m755 $f $$tgt;${call varsubst,$$tgt};)
-	$(foreach f,${SHELLLIBS},install -m644 $f ${SHARE_DIR})
+	$(foreach f,${SHELLLIBS},tgt=${SHARE_DIR}/$$(basename $f);\
+		install -m644 $f $$tgt;${call varsubstlibs,$$tgt};)
 	$(foreach f,${UDEVRULES},install -m644 $f ${UDEVDIR};)
 	$(foreach f,$(wildcard systemd/network/*.network),install -m644 $f ${SYSTEMD_NETWORK_DIR};)
 	$(foreach f,$(wildcard systemd/system/*.service systemd/system/*.timer),install -m644 $f ${SYSTEMD_SYSTEM_DIR};)

--- a/amazon-ec2-net-utils.spec
+++ b/amazon-ec2-net-utils.spec
@@ -1,5 +1,5 @@
 Name:    amazon-ec2-net-utils
-%define  base_version 2.6.0
+%define  base_version 2.7.0
 %define  source_version %{base_version}%{?_source_version_suffix}
 Version: %{base_version}%{?_rpm_version_suffix}
 Release: 1%{?dist}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+amazon-ec2-net-utils (2.7.0) unstable; urgency=medium
+
+  * New upstream release 2.7.0
+
+ -- Joe Kurokawa <joekurok@amazon.com>  Thu, 26 Jun 2025  01:04:33 +0000
+
 amazon-ec2-net-utils (2.6.0) unstable; urgency=medium
 
   * New upstream release 2.6.0

--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -19,6 +19,12 @@ declare unitdir
 declare lockdir
 declare reload_flag
 
+# Version information - substituted during installation
+declare PACKAGE_VERSION="AMAZON_EC2_NET_UTILS_VERSION"
+if [ -z "$PACKAGE_VERSION" ]; then
+    PACKAGE_VERSION="unknown"
+fi
+declare -r USER_AGENT="amazon-ec2-net-utils/$PACKAGE_VERSION"
 declare -r imds_endpoints=("http://169.254.169.254/latest" "http://[fd00:ec2::254]/latest")
 declare -r imds_token_path="api/token"
 declare -r syslog_facility="user"
@@ -39,7 +45,15 @@ declare self_iface_name=""
 make_token_request() {
     local ep=${1:-""}
     local interface=${2:-""}
-    local -a curl_opts=(--max-time 5 --connect-timeout 0.15 -s --fail -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+    local -a curl_opts=(
+        --max-time 5
+        --connect-timeout 0.15
+        -s
+        --fail
+        -X PUT 
+        -H "X-aws-ec2-metadata-token-ttl-seconds: 60"
+        -A "$USER_AGENT"
+        )
     if [ -n "$interface" ]; then
         curl_opts+=(--interface "$interface")
     fi
@@ -133,7 +147,12 @@ get_meta() {
     fi
     local url="${imds_endpoint}/meta-data/${key}"
     local meta rc
-    local curl_opts=(-s --max-time 5 -H "X-aws-ec2-metadata-token:${imds_token}" -f)
+    local curl_opts=(
+        -s 
+        --max-time 5 
+        -H "X-aws-ec2-metadata-token:${imds_token}" 
+        -f 
+        -A "$USER_AGENT")
     if [[ "$imds_interface" != "$default_route" ]]; then
         curl_opts+=(--interface "$imds_interface")
     fi


### PR DESCRIPTION
In order to track metrics in IMDS we have to make identifying calls from this package with a unique User-Agent header.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Tested the change using TCP dump:

```
        GET /latest/meta-data/network/interfaces/macs/02:ca:ba:d2:fd:37/local-ipv4s HTTP/1.1
        Host: 169.254.169.254
        User-Agent: amazon-ec2-net-utils/2.6.1
        Accept: */*
        X-aws-ec2-metadata-token:............
```
