### PR TITLE
lib.sh: fix reload check

### DIFF
--- a/lib/lib.sh
+++ b/lib/lib.sh
@@ -596,7 +596,7 @@ setup_interface() {
 # they're the registered process running.
 maybe_reload_networkd() {
     rm -f "${lockdir}/${iface}"
-    if rmdir "$lockdir" 2> /dev/null; then
+    if [ ! -d "$lockdir" ] || rmdir "$lockdir" 2> /dev/null; then
         if [ -e "$reload_flag" ]; then
             rm -f "$reload_flag" 2> /dev/null
             networkctl reload


### PR DESCRIPTION
Issue #122

rmdir will never succeed if there is directory. 

Without this it causes issues like if there are two interfaces, and each only gets one event ever, the reload never succeeds for the second interface. The sentinel flag gets created and sits forever.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
