### PR TITLE
Secondary IP refresh and IMDS token optimization

### DIFF
--- a/bin/setup-policy-routes.sh
+++ b/bin/setup-policy-routes.sh
@@ -42,6 +42,7 @@ do_setup() {
 
 case "$2" in
 refresh)
+    register_networkd_reloader
     [ -e "/sys/class/net/${iface}" ] || exit 0
     info "Starting configuration refresh for $iface"
     do_setup


### PR DESCRIPTION
This change adds back secondary ip refresh feature which was broken. Now, when a secondary ip is assigned or unassigned it will automatically show up on the host after 60s. Also optimized IMDS token calls such that one token is requested per ENI for a start or refresh cycle. This significantly reduces the number of IMDS token requested per ENI.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
