### PR TITLE
fix: add systemd-networkd ordering and wait-online timeout

### DIFF
--- a/bin/setup-policy-routes.sh
+++ b/bin/setup-policy-routes.sh
@@ -64,8 +64,8 @@ start)
         fi
     done
     debug "Starting configuration for $iface"
-    debug /lib/systemd/systemd-networkd-wait-online -i "$iface"
-    /lib/systemd/systemd-networkd-wait-online -i "$iface"
+    debug /lib/systemd/systemd-networkd-wait-online -i "$iface" --timeout=60
+    /lib/systemd/systemd-networkd-wait-online -i "$iface" --timeout=60
     export EC2_IF_INITIAL_SETUP=1
     do_setup
     ;;

--- a/systemd/system/policy-routes@.service
+++ b/systemd/system/policy-routes@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Set up policy routes for %I
-StartLimitIntervalSec=10
+After=systemd-networkd.service
+StartLimitIntervalSec=60
 StartLimitBurst=5
 Wants=refresh-policy-routes@%i.timer
 CollectMode=inactive-or-failed


### PR DESCRIPTION
Fixes #168

When a DHCP lease is lost during boot (e.g. another service calls `networkctl reload`), the systemd-networkd DHCP client may stop requesting rather than retrying. `policy-routes@.service` then loops on `systemd-networkd-wait-online` with no explicit timeout, blocking indefinitely.

This PR:
- Adds `After=systemd-networkd.service` to reduce the race window on boot
- Adds `--timeout=60` for bounded wait and faster retry cycle
- Increases `StartLimitIntervalSec` from 10 to 60 to prevent permanent failure when wait-online fails quickly in a transient state

Journal evidence and full analysis in #168.

> **Update 1 of PR:** Revised based on review feedback from Joe and some more insights from AWS Support: Removed `Wants=systemd-networkd.service` (only ordering needed, not dependency pull). Changed `StartLimitIntervalSec` from 300 to 60 to avoid delaying recovery after transient IMDS failures. Corrected root cause description: DHCP client stops requesting, not server failing to respond.